### PR TITLE
Override GRADLE_USER_HOME to fix caching issues

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -19,12 +19,6 @@ jobs:
     runs-on: ubuntu-latest
     container: fedora:latest
 
-    # Don't use env context in run scripts (use normal bash variable substitution instead),
-    # it will have wrong workspace path inside container
-    env:
-      ANDROID_SDK_ROOT: ${{github.workspace}}/android-sdk
-      SDKMANAGER: ${{github.workspace}}/android-sdk/cmdline-tools/latest/bin/sdkmanager
-
     # Steps represent a sequence of tasks that will be executed as part of the job
     steps:
       - name: Install host dependencies
@@ -37,11 +31,17 @@ jobs:
           submodules: true
           fetch-depth: 0
 
+      - name: Set Android SDK environment variables
+        run: |
+          readonly sdk="$RUNNER_TEMP/android-sdk"
+          echo "ANDROID_SDK_ROOT=$sdk" >> "$GITHUB_ENV"
+          echo "SDKMANAGER=$sdk/cmdline-tools/latest/bin/sdkmanager" >> "$GITHUB_ENV"
+
       - name: Restore Android SDK from cache
         id: android-sdk-cache
         uses: equeim/cache@v2-altered
         with:
-          path: ${{env.ANDROID_SDK_ROOT}}
+          path: ${{ env.ANDROID_SDK_ROOT }}
           key: android-sdk-${{ runner.os }}-${{ hashFiles('**/*.gradle.kts', 'gradle-plugin/**/*.kt') }}
           restore-keys: android-sdk-${{ runner.os }}-
           save-cache: ${{ github.event_name == 'push' }}
@@ -66,7 +66,7 @@ jobs:
       - name: Restore ccache directory from cache
         uses: equeim/cache@v2-altered
         with:
-          path: .ccache
+          path: ${{ runner.temp }}/.ccache
           key: ${{ env.CCACHE_CACHE_KEY }}
           restore-keys: ccache-${{ runner.os }}-
           save-cache: ${{ github.event_name == 'push' }}
@@ -78,8 +78,9 @@ jobs:
           arguments: --info -P org.equeim.tremotesf.ccache=true build
           cache-read-only: ${{ github.event_name != 'push' }}
         env:
+          GRADLE_USER_HOME: ${{ runner.temp }}/.gradle
           CCACHE_BASEDIR: ${{ github.workspace }}
-          CCACHE_DIR: ${{ github.workspace }}/.ccache
+          CCACHE_DIR: ${{ runner.temp }}/.ccache
           CCACHE_COMPRESS: true
           CCACHE_COMPRESSLEVEL: 3
           CCACHE_MAXSIZE: 1G


### PR DESCRIPTION
It seems that Gradle and gradle-build-action doesn't agree
where .gradle directory should be located by default.
Set GRADLE_USER_HOME environment variable to do it for them.