### PR TITLE
Change meaning of "seeders" and "leechers" on torrent's details screen

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,8 @@
 
 ### Changed
 - When relative time displayed for torrent's added/created/last active dates, absolute date and time is also shown
+- "Seeders" and "leechers" now refer to total number of seeders and leechers reported by trackers,
+  while number of peers that we are currently downloading from / uploading to is displayed separately
 
 ### Fixed
 - Fixed display of trackers' next update time

--- a/app/src/main/kotlin/org/equeim/tremotesf/ui/torrentpropertiesfragment/TorrentDetailsFragment.kt
+++ b/app/src/main/kotlin/org/equeim/tremotesf/ui/torrentpropertiesfragment/TorrentDetailsFragment.kt
@@ -70,9 +70,11 @@ class TorrentDetailsFragment :
             uploadSpeedTextView.text =
                 FormatUtils.formatByteSpeed(requireContext(), torrent.uploadSpeed)
             etaTextView.text = FormatUtils.formatDuration(requireContext(), torrent.eta)
-            seedersTextView.text = torrent.activeSeedersCount.toString()
-            webSeedersTextView.text = torrent.activeWebSeedersCount.toString()
-            leechersTextView.text = torrent.activeLeechersCount.toString()
+            seedersTextView.text = torrent.data.totalSeedersFromTrackersCount.toString()
+            leechersTextView.text = torrent.data.totalLeechersFromTrackersCount.toString()
+            peersSendingToUsTextView.text = torrent.peersSendingToUsCount.toString()
+            webSeedersSendingToUsTextView.text = torrent.webSeedersSendingToUsCount.toString()
+            peersGettingFromUsTextView.text = torrent.peersGettingFromUsCount.toString()
             lastActivityTextView.text =
                 torrent.data.activityDate?.toDisplayString()
 

--- a/app/src/main/kotlin/org/equeim/tremotesf/ui/torrentslistfragment/TorrentsAdapter.kt
+++ b/app/src/main/kotlin/org/equeim/tremotesf/ui/torrentslistfragment/TorrentsAdapter.kt
@@ -392,19 +392,19 @@ private fun Torrent.getStatusString(context: Context): CharSequence {
                 context.getText(R.string.torrent_downloading_stalled)
             }
         } else {
-            val seeders = this.activeSeedersCount + this.activeWebSeedersCount
+            val peers = this.peersSendingToUsCount + this.webSeedersSendingToUsCount
             if (hasError) {
                 context.resources.getQuantityString(
                     R.plurals.torrent_downloading_with_error,
-                    seeders,
-                    seeders,
+                    peers,
+                    peers,
                     errorString
                 )
             } else {
                 context.resources.getQuantityString(
                     R.plurals.torrent_downloading,
-                    seeders,
-                    seeders
+                    peers,
+                    peers
                 )
             }
         }
@@ -418,15 +418,15 @@ private fun Torrent.getStatusString(context: Context): CharSequence {
             if (hasError) {
                 context.resources.getQuantityString(
                     R.plurals.torrent_seeding_with_error,
-                    activeLeechersCount,
-                    activeLeechersCount,
+                    peersGettingFromUsCount,
+                    peersGettingFromUsCount,
                     errorString
                 )
             } else {
                 context.resources.getQuantityString(
                     R.plurals.torrent_seeding,
-                    activeLeechersCount,
-                    activeLeechersCount
+                    peersGettingFromUsCount,
+                    peersGettingFromUsCount
                 )
             }
         }

--- a/app/src/main/res/layout/torrent_details_fragment.xml
+++ b/app/src/main/res/layout/torrent_details_fragment.xml
@@ -151,11 +151,11 @@
             android:layout_width="0dp"
             android:layout_marginTop="@dimen/linear_layout_vertical_spacing"
             android:maxLines="2"
-            android:text="@string/active_web_seeders"
+            android:text="@string/leechers"
             app:layout_columnWeight="1"/>
 
         <TextView
-            android:id="@+id/web_seeders_text_view"
+            android:id="@+id/leechers_text_view"
             android:layout_width="0dp"
             android:layout_marginStart="8dp"
             android:layout_marginTop="@dimen/linear_layout_vertical_spacing"
@@ -167,11 +167,43 @@
             android:layout_width="0dp"
             android:layout_marginTop="@dimen/linear_layout_vertical_spacing"
             android:maxLines="2"
-            android:text="@string/leechers"
+            android:text="@string/peers_sending_to_us"
             app:layout_columnWeight="1"/>
 
         <TextView
-            android:id="@+id/leechers_text_view"
+            android:id="@+id/peers_sending_to_us_text_view"
+            android:layout_width="0dp"
+            android:layout_marginStart="8dp"
+            android:layout_marginTop="@dimen/linear_layout_vertical_spacing"
+            android:ellipsize="end"
+            android:maxLines="2"
+            app:layout_columnWeight="2"/>
+
+        <TextView
+            android:layout_width="0dp"
+            android:layout_marginTop="@dimen/linear_layout_vertical_spacing"
+            android:maxLines="2"
+            android:text="@string/web_seeders_sending_to_us"
+            app:layout_columnWeight="1"/>
+
+        <TextView
+            android:id="@+id/web_seeders_sending_to_us_text_view"
+            android:layout_width="0dp"
+            android:layout_marginStart="8dp"
+            android:layout_marginTop="@dimen/linear_layout_vertical_spacing"
+            android:ellipsize="end"
+            android:maxLines="2"
+            app:layout_columnWeight="2"/>
+
+        <TextView
+            android:layout_width="0dp"
+            android:layout_marginTop="@dimen/linear_layout_vertical_spacing"
+            android:maxLines="2"
+            android:text="@string/peers_getting_from_us"
+            app:layout_columnWeight="1"/>
+
+        <TextView
+            android:id="@+id/peers_getting_from_us_text_view"
             android:layout_width="0dp"
             android:layout_marginStart="8dp"
             android:layout_marginTop="@dimen/linear_layout_vertical_spacing"

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -102,8 +102,10 @@
     <string name="download_speed">Download speed</string>
     <string name="upload_speed">Upload speed</string>
     <string name="seeders">Seeders</string>
-    <string name="active_web_seeders">Active web seeders</string>
     <string name="leechers">Leechers</string>
+    <string name="peers_sending_to_us">Peers we\'re downloading from</string>
+    <string name="web_seeders_sending_to_us">Web seeders we\'re downloading from</string>
+    <string name="peers_getting_from_us">Peers we\'re uploading to</string>
     <string name="last_activity">Last activity</string>
 
     <string name="total_size">Total size</string>

--- a/libtremotesf/src/main/cpp/libtremotesf_wrap.cxx
+++ b/libtremotesf/src/main/cpp/libtremotesf_wrap.cxx
@@ -5088,7 +5088,7 @@ SWIGEXPORT jint JNICALL Java_org_equeim_libtremotesf_libtremotesfJNI_TorrentData
 }
 
 
-SWIGEXPORT jint JNICALL Java_org_equeim_libtremotesf_libtremotesfJNI_TorrentData_1activeSeedersCount_1get(JNIEnv *jenv, jclass jcls, jlong jarg1, jobject jarg1_) {
+SWIGEXPORT jint JNICALL Java_org_equeim_libtremotesf_libtremotesfJNI_TorrentData_1peersSendingToUsCount_1get(JNIEnv *jenv, jclass jcls, jlong jarg1, jobject jarg1_) {
   jint jresult = 0 ;
   libtremotesf::TorrentData *arg1 = (libtremotesf::TorrentData *) 0 ;
   int result;
@@ -5097,7 +5097,7 @@ SWIGEXPORT jint JNICALL Java_org_equeim_libtremotesf_libtremotesfJNI_TorrentData
   (void)jcls;
   (void)jarg1_;
   arg1 = *(libtremotesf::TorrentData **)&jarg1; 
-  result = (int) ((arg1)->activeSeedersCount);
+  result = (int) ((arg1)->peersSendingToUsCount);
   jresult = (jint)result; 
   return jresult;
 }
@@ -5118,7 +5118,7 @@ SWIGEXPORT jlong JNICALL Java_org_equeim_libtremotesf_libtremotesfJNI_TorrentDat
 }
 
 
-SWIGEXPORT jint JNICALL Java_org_equeim_libtremotesf_libtremotesfJNI_TorrentData_1activeWebSeedersCount_1get(JNIEnv *jenv, jclass jcls, jlong jarg1, jobject jarg1_) {
+SWIGEXPORT jint JNICALL Java_org_equeim_libtremotesf_libtremotesfJNI_TorrentData_1webSeedersSendingToUsCount_1get(JNIEnv *jenv, jclass jcls, jlong jarg1, jobject jarg1_) {
   jint jresult = 0 ;
   libtremotesf::TorrentData *arg1 = (libtremotesf::TorrentData *) 0 ;
   int result;
@@ -5127,7 +5127,7 @@ SWIGEXPORT jint JNICALL Java_org_equeim_libtremotesf_libtremotesfJNI_TorrentData
   (void)jcls;
   (void)jarg1_;
   arg1 = *(libtremotesf::TorrentData **)&jarg1; 
-  result = (int) ((arg1)->activeWebSeedersCount);
+  result = (int) ((arg1)->webSeedersSendingToUsCount);
   jresult = (jint)result; 
   return jresult;
 }
@@ -5148,7 +5148,7 @@ SWIGEXPORT jint JNICALL Java_org_equeim_libtremotesf_libtremotesfJNI_TorrentData
 }
 
 
-SWIGEXPORT jint JNICALL Java_org_equeim_libtremotesf_libtremotesfJNI_TorrentData_1activeLeechersCount_1get(JNIEnv *jenv, jclass jcls, jlong jarg1, jobject jarg1_) {
+SWIGEXPORT jint JNICALL Java_org_equeim_libtremotesf_libtremotesfJNI_TorrentData_1peersGettingFromUsCount_1get(JNIEnv *jenv, jclass jcls, jlong jarg1, jobject jarg1_) {
   jint jresult = 0 ;
   libtremotesf::TorrentData *arg1 = (libtremotesf::TorrentData *) 0 ;
   int result;
@@ -5157,7 +5157,7 @@ SWIGEXPORT jint JNICALL Java_org_equeim_libtremotesf_libtremotesfJNI_TorrentData
   (void)jcls;
   (void)jarg1_;
   arg1 = *(libtremotesf::TorrentData **)&jarg1; 
-  result = (int) ((arg1)->activeLeechersCount);
+  result = (int) ((arg1)->peersGettingFromUsCount);
   jresult = (jint)result; 
   return jresult;
 }

--- a/libtremotesf/src/main/java/org/equeim/libtremotesf/TorrentData.java
+++ b/libtremotesf/src/main/java/org/equeim/libtremotesf/TorrentData.java
@@ -160,8 +160,8 @@ public class TorrentData {
     return libtremotesfJNI.TorrentData_totalSeedersFromTrackersCount_get(swigCPtr, this);
   }
 
-  public int getActiveSeedersCount() {
-    return libtremotesfJNI.TorrentData_activeSeedersCount_get(swigCPtr, this);
+  public int getPeersSendingToUsCount() {
+    return libtremotesfJNI.TorrentData_peersSendingToUsCount_get(swigCPtr, this);
   }
 
   public StringsVector getWebSeeders() {
@@ -169,16 +169,16 @@ public class TorrentData {
     return (cPtr == 0) ? null : new StringsVector(cPtr, false);
   }
 
-  public int getActiveWebSeedersCount() {
-    return libtremotesfJNI.TorrentData_activeWebSeedersCount_get(swigCPtr, this);
+  public int getWebSeedersSendingToUsCount() {
+    return libtremotesfJNI.TorrentData_webSeedersSendingToUsCount_get(swigCPtr, this);
   }
 
   public int getTotalLeechersFromTrackersCount() {
     return libtremotesfJNI.TorrentData_totalLeechersFromTrackersCount_get(swigCPtr, this);
   }
 
-  public int getActiveLeechersCount() {
-    return libtremotesfJNI.TorrentData_activeLeechersCount_get(swigCPtr, this);
+  public int getPeersGettingFromUsCount() {
+    return libtremotesfJNI.TorrentData_peersGettingFromUsCount_get(swigCPtr, this);
   }
 
   public int getPeersLimit() {

--- a/libtremotesf/src/main/java/org/equeim/libtremotesf/libtremotesfJNI.java
+++ b/libtremotesf/src/main/java/org/equeim/libtremotesf/libtremotesfJNI.java
@@ -203,11 +203,11 @@ public class libtremotesfJNI {
   public final static native double TorrentData_ratioLimit_get(long jarg1, TorrentData jarg1_);
   public final static native int TorrentData_ratioLimitMode_get(long jarg1, TorrentData jarg1_);
   public final static native int TorrentData_totalSeedersFromTrackersCount_get(long jarg1, TorrentData jarg1_);
-  public final static native int TorrentData_activeSeedersCount_get(long jarg1, TorrentData jarg1_);
+  public final static native int TorrentData_peersSendingToUsCount_get(long jarg1, TorrentData jarg1_);
   public final static native long TorrentData_webSeeders_get(long jarg1, TorrentData jarg1_);
-  public final static native int TorrentData_activeWebSeedersCount_get(long jarg1, TorrentData jarg1_);
+  public final static native int TorrentData_webSeedersSendingToUsCount_get(long jarg1, TorrentData jarg1_);
   public final static native int TorrentData_totalLeechersFromTrackersCount_get(long jarg1, TorrentData jarg1_);
-  public final static native int TorrentData_activeLeechersCount_get(long jarg1, TorrentData jarg1_);
+  public final static native int TorrentData_peersGettingFromUsCount_get(long jarg1, TorrentData jarg1_);
   public final static native int TorrentData_peersLimit_get(long jarg1, TorrentData jarg1_);
   public final static native long TorrentData_addedDate_get(long jarg1, TorrentData jarg1_);
   public final static native long TorrentData_activityDate_get(long jarg1, TorrentData jarg1_);

--- a/rpc/src/main/kotlin/org/equeim/tremotesf/torrentfile/rpc/Torrent.kt
+++ b/rpc/src/main/kotlin/org/equeim/tremotesf/torrentfile/rpc/Torrent.kt
@@ -55,9 +55,9 @@ class Torrent private constructor(
     val totalUploaded = data.totalUploaded
     val ratio = data.ratio
 
-    val activeSeedersCount = data.activeSeedersCount
-    val activeWebSeedersCount = data.activeWebSeedersCount
-    val activeLeechersCount = data.activeLeechersCount
+    val peersSendingToUsCount = data.peersSendingToUsCount
+    val webSeedersSendingToUsCount = data.webSeedersSendingToUsCount
+    val peersGettingFromUsCount = data.peersGettingFromUsCount
 
     val addedDate: Instant? = data.addedDate
 


### PR DESCRIPTION
"Seeders" and "leechers" now refer to total number of seeders and leechers reported by trackers, while number of peers that we are currently downloading from / uploading to is displayed separately.