### PR TITLE
Fix peer progress percentages

### DIFF
--- a/app/src/main/kotlin/org/equeim/tremotesf/ui/torrentpropertiesfragment/PeersTab.kt
+++ b/app/src/main/kotlin/org/equeim/tremotesf/ui/torrentpropertiesfragment/PeersTab.kt
@@ -117,7 +117,7 @@ fun PeersTab(
                                         Text(
                                             stringResource(
                                                 R.string.progress_string,
-                                                progressFormatter.format(peer.progress)
+                                                progressFormatter.format(peer.progress * 100)
                                             )
                                         )
                                         Text(peer.client)


### PR DESCRIPTION
Fixes #362

Pretty sure this is the right fix, just restoring the behaviour from 2.12.1: https://github.com/equeim/tremotesf-android/blob/2.12.1/app/src/main/kotlin/org/equeim/tremotesf/ui/torrentpropertiesfragment/PeersAdapter.kt#L67