### PR TITLE
Implement IPv4-only mode for RPC connection

### DIFF
--- a/app/src/main/kotlin/org/equeim/tremotesf/ui/connectionsettingsfragment/ServerEditFragment.kt
+++ b/app/src/main/kotlin/org/equeim/tremotesf/ui/connectionsettingsfragment/ServerEditFragment.kt
@@ -130,6 +130,7 @@ class ServerEditFragment : ComposeFragment() {
             name = model.name,
             address = model.address,
             port = model.port,
+            useIPv4Only = model.useIPv4Only,
             httpsEnabled = model.httpsEnabled,
             apiPath = model.apiPath,
             authentication = model.authentication,
@@ -158,6 +159,7 @@ private fun ServerEditScreen(
     name: MutableState<String>,
     address: MutableState<String>,
     port: TremotesfIntegerNumberInputFieldState,
+    useIPv4Only: MutableState<Boolean>,
     httpsEnabled: MutableState<Boolean>,
     apiPath: MutableState<String>,
     authentication: MutableState<Boolean>,
@@ -327,6 +329,14 @@ private fun ServerEditScreen(
                 modifier = Modifier
                     .fillMaxWidth()
                     .padding(horizontal = horizontalPadding)
+            )
+
+            TremotesfSwitchWithText(
+                checked = useIPv4Only.value,
+                text = R.string.use_ipv4_only,
+                onCheckedChange = useIPv4Only::value::set,
+                modifier = Modifier.fillMaxWidth(),
+                horizontalContentPadding = horizontalPadding
             )
 
             TremotesfSwitchWithText(
@@ -642,6 +652,7 @@ private fun ServerEditScreenPreview() = ScreenPreview {
         name = remember { mutableStateOf("hmm") },
         address = remember { mutableStateOf("4.2.4.2") },
         port = rememberTremotesfIntegerNumberInputFieldState(42),
+        useIPv4Only = remember { mutableStateOf(false) },
         httpsEnabled = remember { mutableStateOf(false) },
         apiPath = remember { mutableStateOf("/lol") },
         authentication = remember { mutableStateOf(false) },
@@ -679,6 +690,7 @@ class ServerEditFragmentViewModel(
     val port by savedStateHandle.saveable(saver = TremotesfIntegerNumberInputFieldState.Saver()) {
         TremotesfIntegerNumberInputFieldState((editingServer.port).toLong())
     }
+    val useIPv4Only by savedStateHandle.saveable<MutableState<Boolean>> { mutableStateOf(editingServer.useIPv4Only) }
     val httpsEnabled by savedStateHandle.saveable<MutableState<Boolean>> { mutableStateOf(editingServer.httpsEnabled) }
     val apiPath by savedStateHandle.saveable<MutableState<String>> { mutableStateOf(editingServer.apiPath) }
     val authentication by savedStateHandle.saveable<MutableState<Boolean>> { mutableStateOf(editingServer.authentication) }
@@ -782,6 +794,7 @@ class ServerEditFragmentViewModel(
             proxyUser = proxyUser.value.trim(),
             proxyPassword = proxyPassword.value.trim(),
 
+            useIPv4Only = useIPv4Only.value,
             httpsEnabled = httpsEnabled.value,
             selfSignedCertificateEnabled = selfSignedCertificateEnabled.value,
             selfSignedCertificate = selfSignedCertificate.value.trim(),

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -565,4 +565,6 @@ SPDX-License-Identifier: GPL-3.0-or-later
     <string name="sort_order">Sort order:</string>
     <string name="ascending">Ascending</string>
     <string name="descending">Descending</string>
+
+    <string name="use_ipv4_only">Use IPv4 only</string>
 </resources>

--- a/rpc/src/main/kotlin/org/equeim/tremotesf/rpc/ConnectionConfiguration.kt
+++ b/rpc/src/main/kotlin/org/equeim/tremotesf/rpc/ConnectionConfiguration.kt
@@ -40,6 +40,7 @@ internal fun createConnectionConfiguration(server: Server, retryOnConnectionFail
                 InetSocketAddress.createUnresolved(server.proxyHostname, server.proxyPort)
             )
         })
+        .dns(DnsFilter(server.useIPv4Only))
     var clientCertificates: List<Certificate> = emptyList()
     val clientCertificate = if (server.clientCertificateEnabled) server.clientCertificate.takeIf { it.isNotBlank() } else null
     val serverCertificate = if (server.selfSignedCertificateEnabled) server.selfSignedCertificate.takeIf { it.isNotBlank() } else null

--- a/rpc/src/main/kotlin/org/equeim/tremotesf/rpc/DnsFilter.kt
+++ b/rpc/src/main/kotlin/org/equeim/tremotesf/rpc/DnsFilter.kt
@@ -1,0 +1,17 @@
+package org.equeim.tremotesf.rpc
+
+import okhttp3.Dns
+import java.net.InetAddress
+import java.net.Inet4Address
+
+class DnsFilter(private val useIPv4Only: Boolean) : Dns {
+	override fun lookup(hostname: String): List<InetAddress> {
+		var addresses = Dns.SYSTEM.lookup(hostname)
+
+		if (useIPv4Only) {
+			addresses = addresses.filter { Inet4Address::class.java.isInstance(it) }
+		}
+
+		return addresses
+	}
+}

--- a/rpc/src/main/kotlin/org/equeim/tremotesf/rpc/Server.kt
+++ b/rpc/src/main/kotlin/org/equeim/tremotesf/rpc/Server.kt
@@ -52,6 +52,8 @@ data class Server(
     @SerialName("proxyPassword")
     val proxyPassword: String = "",
 
+    @SerialName("useIPv4Only")
+    val useIPv4Only: Boolean = false,
     @SerialName("httpsEnabled")
     val httpsEnabled: Boolean = false,
     @SerialName("selfSignedCertificateEnabled")


### PR DESCRIPTION
As simple as the title is. Sometimes IPv6 setup may be wanky or unreliable, so providing a way of opting out of it should be an option.

- Adds a toggle in server connection settings named "Use IPv4 Only"
- Performs filtering of DNS records returned from the resolver if such toggle is enabled in the settings