### PR TITLE
Fix crash caused by duplicate peer connections

### DIFF
--- a/app/src/main/kotlin/org/equeim/tremotesf/ui/torrentpropertiesfragment/PeersTab.kt
+++ b/app/src/main/kotlin/org/equeim/tremotesf/ui/torrentpropertiesfragment/PeersTab.kt
@@ -83,7 +83,7 @@ fun PeersTab(
 
             val comparator =
                 rememberLocaleDependentValue { compareBy(AlphanumericComparator(), Peer::address) }
-            val sortedPeers = remember { derivedStateOf { peers.sortedWith(comparator) } }
+            val sortedPeers = remember { derivedStateOf { peers.sortedWith(comparator).distinctBy(Peer::address) } }
 
             LazyColumn(
                 state = listState,


### PR DESCRIPTION
Sometimes when opening the "Peers" tab on a torrent the app will crash:

```
FATAL EXCEPTION: main
Process: org.equeim.tremotesf.debug, PID: 25284
java.lang.IllegalArgumentException: Key "<redacted IP>" was already used. If you are using LazyColumn/Row please make sure you provide a unique key for each item.
	at androidx.compose.ui.internal.InlineClassHelperKt.throwIllegalArgumentException(InlineClassHelper.kt:36)
	at androidx.compose.ui.layout.LayoutNodeSubcompositionsState.subcompose(SubcomposeLayout.kt:1366)
	at androidx.compose.ui.layout.LayoutNodeSubcompositionsState$Scope.subcompose(SubcomposeLayout.kt:1231)
	at androidx.compose.foundation.lazy.layout.LazyLayoutMeasureScopeImpl.compose(LazyLayoutMeasureScope.kt:94)
	at androidx.compose.foundation.lazy.layout.LazyLayoutMeasuredItemProvider.getPlaceables-3p2s80s(LazyLayoutMeasuredItem.kt:60)
	at androidx.compose.foundation.lazy.LazyListMeasuredItemProvider.getAndMeasure-0kLqBqw(LazyListMeasuredItemProvider.kt:53)
	at androidx.compose.foundation.lazy.LazyListMeasuredItemProvider.getAndMeasure-0kLqBqw$default(LazyListMeasuredItemProvider.kt:47)
	at androidx.compose.foundation.lazy.LazyListMeasureKt.measureLazyList-LCrQqZ4(LazyListMeasure.kt:224)
	at androidx.compose.foundation.lazy.LazyListKt$rememberLazyListMeasurePolicy$1$1.measure-0kLqBqw(LazyList.kt:354)
	at androidx.compose.foundation.lazy.layout.LazyLayoutKt$LazyLayout$2.invoke$lambda$8$lambda$7(LazyLayout.kt:141)
	at androidx.compose.foundation.lazy.layout.LazyLayoutKt$LazyLayout$2.$r8$lambda$AuADrFew1M7xDLhV5Co4CIX8-dw(Unknown Source:0)
	at androidx.compose.foundation.lazy.layout.LazyLayoutKt$LazyLayout$2$$ExternalSyntheticLambda2.invoke(D8$$SyntheticClass:0)
	at androidx.compose.ui.layout.LayoutNodeSubcompositionsState$createMeasurePolicy$1.measure-3p2s80s(SubcomposeLayout.kt:914)
	at androidx.compose.ui.node.InnerNodeCoordinator.measure-BRTryo0(InnerNodeCoordinator.kt:128)
	at androidx.compose.ui.graphics.SimpleGraphicsLayerModifier.measure-3p2s80s(GraphicsLayerModifier.kt:794)
	at androidx.compose.ui.node.LayoutModifierNodeCoordinator.measure-BRTryo0(LayoutModifierNodeCoordinator.kt:190)
	at androidx.compose.foundation.lazy.layout.LazyLayoutBeyondBoundsModifierNode.measure-3p2s80s(LazyLayoutBeyondBoundsModifierLocal.kt:118)
	at androidx.compose.ui.node.LayoutModifierNodeCoordinator.measure-BRTryo0(LayoutModifierNodeCoordinator.kt:190)
	at androidx.compose.foundation.layout.FillNode.measure-3p2s80s(Size.kt:721)
	at androidx.compose.ui.node.LayoutModifierNodeCoordinator.measure-BRTryo0(LayoutModifierNodeCoordinator.kt:190)
	at androidx.compose.ui.node.MeasurePassDelegate$performMeasureBlock$1.invoke(MeasurePassDelegate.kt:173)
	at androidx.compose.ui.node.MeasurePassDelegate$performMeasureBlock$1.invoke(MeasurePassDelegate.kt:172)
	at androidx.compose.runtime.snapshots.Snapshot$Companion.observe(Snapshot.kt:502)
	at androidx.compose.runtime.snapshots.SnapshotStateObserver$ObservedScopeMap.observe(SnapshotStateObserver.kt:464)
	at androidx.compose.runtime.snapshots.SnapshotStateObserver.observeReads(SnapshotStateObserver.kt:248)
	at androidx.compose.ui.node.OwnerSnapshotObserver.observeReads$ui_release(OwnerSnapshotObserver.kt:124)
	at androidx.compose.ui.node.OwnerSnapshotObserver.observeMeasureSnapshotReads$ui_release(OwnerSnapshotObserver.kt:107)
	at androidx.compose.ui.node.MeasurePassDelegate.performMeasure-BRTryo0$ui_release(MeasurePassDelegate.kt:426)
	at androidx.compose.ui.node.MeasurePassDelegate.remeasure-BRTryo0(MeasurePassDelegate.kt:477)
	at androidx.compose.ui.node.MeasurePassDelegate.measure-BRTryo0(MeasurePassDelegate.kt:454)
	at androidx.compose.foundation.layout.BoxMeasurePolicy.measure-3p2s80s(Box.kt:145)
	at androidx.compose.ui.node.InnerNodeCoordinator.measure-BRTryo0(InnerNodeCoordinator.kt:128)
	at androidx.compose.foundation.layout.FillNode.measure-3p2s80s(Size.kt:721)
	at androidx.compose.ui.node.LayoutModifierNodeCoordinator.measure-BRTryo0(LayoutModifierNodeCoordinator.kt:190)
	at androidx.compose.ui.node.MeasurePassDelegate$performMeasureBlock$1.invoke(MeasurePassDelegate.kt:173)
```

For some reason, certain torrents (in bad states I think?) will have multiple connections to the same peer, even multiple connections with the same port:

<img width="679" height="162" alt="Screenshot From 2026-06-02 15-30-29" src="https://github.com/user-attachments/assets/80d61429-682e-4342-bbca-00bb48ad028b" />

Not sure exactly why this happens, but removing these duplicates should be a quick fix.