### PR TITLE
Open license links in the browser instead of the About WebView

### DIFF
--- a/app/src/main/kotlin/org/equeim/tremotesf/ui/AboutFragment.kt
+++ b/app/src/main/kotlin/org/equeim/tremotesf/ui/AboutFragment.kt
@@ -5,8 +5,11 @@
 package org.equeim.tremotesf.ui
 
 import android.annotation.SuppressLint
+import android.content.ActivityNotFoundException
 import android.content.Context
+import android.content.Intent
 import android.view.View
+import android.webkit.WebResourceRequest
 import android.webkit.WebView
 import android.webkit.WebViewClient
 import androidx.compose.foundation.layout.Arrangement
@@ -328,6 +331,20 @@ private fun createLicenseWebView(context: Context, onLoaded: WebView.() -> Unit)
         @SuppressLint("SetJavaScriptEnabled")
         settings.javaScriptEnabled = true
         webViewClient = object : WebViewClient() {
+            override fun shouldOverrideUrlLoading(view: WebView, request: WebResourceRequest): Boolean {
+                val scheme = request.url.scheme?.lowercase()
+                if (scheme != "http" && scheme != "https" && scheme != "mailto") {
+                    return false
+                }
+                return try {
+                    context.startActivity(Intent(Intent.ACTION_VIEW, request.url))
+                    true
+                } catch (e: ActivityNotFoundException) {
+                    Timber.e(e, "Failed to open ${request.url}")
+                    false
+                }
+            }
+
             override fun onPageFinished(view: WebView?, url: String?) {
                 super.onPageFinished(view, url)
                 onLoaded()


### PR DESCRIPTION
The license WebView in `createLicenseWebView` had no link handling, so tapping a link in the license text (for example the gnu.org or fsf.org URLs in the GPL notice) loaded that page inside the About screen and replaced the license, with no way back.

This adds `shouldOverrideUrlLoading` to that client. `http`, `https` and `mailto` links now open through `Intent.ACTION_VIEW`, so they go to the browser or mail app and the license stays in the About screen. Same page anchors and other schemes are left to the WebView as before. If no app can handle the link it is logged and ignored instead of throwing.

Closes #378
