### PR TITLE
Fix seed queue enabled setting

### DIFF
--- a/app/src/main/kotlin/org/equeim/tremotesf/ui/serversettingsfragment/QueueFragment.kt
+++ b/app/src/main/kotlin/org/equeim/tremotesf/ui/serversettingsfragment/QueueFragment.kt
@@ -128,7 +128,7 @@ private fun ServerSettingsQueueScreen(
         TremotesfSwitchWithText(
             checked = seedQueueEnabled.value,
             text = R.string.maximum_active_uploads,
-            onCheckedChange = downloadQueueEnabled::update,
+            onCheckedChange = seedQueueEnabled::update,
             modifier = Modifier.fillMaxWidth(),
             horizontalContentPadding = horizontalPadding
         )


### PR DESCRIPTION
Fixed the "Maximum active uploads"/`seedQueueEnabled` setting actually enabling the "Maximum active downloads"/`downloadQueueEnabled` setting.