### PR TITLE
Use keyed SideEffect instead of LaunchedEffect where possible

### DIFF
--- a/app/src/main/kotlin/org/equeim/tremotesf/ui/addtorrent/AddTorrentCommon.kt
+++ b/app/src/main/kotlin/org/equeim/tremotesf/ui/addtorrent/AddTorrentCommon.kt
@@ -28,6 +28,7 @@ import androidx.compose.runtime.Composable
 import androidx.compose.runtime.CompositionLocalProvider
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.MutableState
+import androidx.compose.runtime.SideEffect
 import androidx.compose.runtime.State
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
@@ -186,7 +187,7 @@ fun HandleFinishedAddTorrentState(
     if (state is AddTorrentState.Finished) {
         val owner = navController.viewModelStoreOwnerForDestinationOrNull<TorrentsListDestination>()
         val activity = checkNotNull(LocalActivity.current) as ComponentActivity
-        LaunchedEffect(null) {
+        SideEffect(Unit) {
             if (state.mergingTrackersMessage != null) {
                 showMergingTrackersMessageAfterAddingTorrent(
                     message = state.mergingTrackersMessage,

--- a/app/src/main/kotlin/org/equeim/tremotesf/ui/addtorrent/AddTorrentFileScreen.kt
+++ b/app/src/main/kotlin/org/equeim/tremotesf/ui/addtorrent/AddTorrentFileScreen.kt
@@ -36,8 +36,8 @@ import androidx.compose.material3.Tab
 import androidx.compose.material3.Text
 import androidx.compose.material3.TopAppBarDefaults
 import androidx.compose.runtime.Composable
-import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.MutableState
+import androidx.compose.runtime.SideEffect
 import androidx.compose.runtime.State
 import androidx.compose.runtime.derivedStateOf
 import androidx.compose.runtime.getValue
@@ -206,7 +206,7 @@ private fun AddTorrentFileScreen(
         }
 
         if (permissionHelperState != null && !permissionHelperState.permissionGranted) {
-            LaunchedEffect(permissionHelperState) {
+            SideEffect(Unit) {
                 permissionHelperState.requestPermission()
             }
 
@@ -221,7 +221,7 @@ private fun AddTorrentFileScreen(
             return@Scaffold
         }
 
-        LaunchedEffect(null) { loadTorrentFile() }
+        SideEffect(Unit) { loadTorrentFile() }
 
         var showDetailedErrorDialog: DetailedRpcRequestError? by rememberSaveable { mutableStateOf(null) }
         showDetailedErrorDialog?.let {

--- a/app/src/main/kotlin/org/equeim/tremotesf/ui/components/BaseTremotesfButtonWithTooltip.kt
+++ b/app/src/main/kotlin/org/equeim/tremotesf/ui/components/BaseTremotesfButtonWithTooltip.kt
@@ -15,7 +15,7 @@ import androidx.compose.material3.TooltipBox
 import androidx.compose.material3.TooltipDefaults
 import androidx.compose.material3.rememberTooltipState
 import androidx.compose.runtime.Composable
-import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.SideEffect
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.platform.LocalView
 import androidx.compose.ui.res.stringResource
@@ -35,7 +35,7 @@ fun BaseTremotesfButtonWithTooltip(
             tooltip = {
                 PlainTooltip { Text(tooltipTextString) }
                 val view = LocalView.current
-                LaunchedEffect(null) { view.performHapticFeedback(HapticFeedbackConstants.LONG_PRESS) }
+                SideEffect(Unit) { view.performHapticFeedback(HapticFeedbackConstants.LONG_PRESS) }
             },
             state = rememberTooltipState(),
             focusable = false

--- a/app/src/main/kotlin/org/equeim/tremotesf/ui/components/TremotesfInitialFocusRequester.kt
+++ b/app/src/main/kotlin/org/equeim/tremotesf/ui/components/TremotesfInitialFocusRequester.kt
@@ -5,7 +5,7 @@
 package org.equeim.tremotesf.ui.components
 
 import androidx.compose.runtime.Composable
-import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.SideEffect
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
@@ -18,7 +18,7 @@ fun rememberTremotesfInitialFocusRequester(): FocusRequester {
     val requester = remember { FocusRequester() }
     var requestedFocus: Boolean by rememberSaveable { mutableStateOf(false) }
     if (!requestedFocus) {
-        LaunchedEffect(null) {
+        SideEffect(Unit) {
             requester.requestFocus()
             requestedFocus = true
         }

--- a/app/src/main/kotlin/org/equeim/tremotesf/ui/components/TremotesfMultiSelection.kt
+++ b/app/src/main/kotlin/org/equeim/tremotesf/ui/components/TremotesfMultiSelection.kt
@@ -27,7 +27,7 @@ import androidx.compose.material3.Surface
 import androidx.compose.material3.Text
 import androidx.compose.material3.VerticalDivider
 import androidx.compose.runtime.Composable
-import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.SideEffect
 import androidx.compose.runtime.Stable
 import androidx.compose.runtime.State
 import androidx.compose.runtime.derivedStateOf
@@ -255,7 +255,7 @@ fun TremotesfMultiSelectionPanelPreview() = ComponentPreview {
         listItems = items,
         keySelector = { it }
     )
-    LaunchedEffect(state) {
+    SideEffect(Unit) {
         state.select("Hmm")
     }
     TremotesfMultiSelectionPanelImpl(

--- a/app/src/main/kotlin/org/equeim/tremotesf/ui/torrentproperties/TorrentPropertiesScreen.kt
+++ b/app/src/main/kotlin/org/equeim/tremotesf/ui/torrentproperties/TorrentPropertiesScreen.kt
@@ -27,7 +27,7 @@ import androidx.compose.material3.Tab
 import androidx.compose.material3.Text
 import androidx.compose.material3.TopAppBarDefaults
 import androidx.compose.runtime.Composable
-import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.SideEffect
 import androidx.compose.runtime.State
 import androidx.compose.runtime.derivedStateOf
 import androidx.compose.runtime.getValue
@@ -87,7 +87,7 @@ data class TorrentPropertiesDestination(val torrentHashString: String) : Destina
             )
         }
         if (model.shouldNavigateUp) {
-            LaunchedEffect(null) { navController.popBackStack() }
+            SideEffect(Unit) { navController.popBackStack() }
         }
         TorrentPropertiesScreen(
             navigateUp = navController::popBackStack,


### PR DESCRIPTION
Remove permissionHelperState when requesting storage persmission since we know it won't change.